### PR TITLE
feat: add GTN network to EthereumNetworks enum

### DIFF
--- a/src/records/dnsTxt.ts
+++ b/src/records/dnsTxt.ts
@@ -26,7 +26,7 @@ export enum EthereumNetworks {
   xdc = "50",
   xdcapothem = "51",
   stabilityTestnet = "20180427",
-  gtn = "101010",
+  stability = "101010",
 }
 
 export enum HederaNetworks {
@@ -47,7 +47,7 @@ export const EthereumNetworkIdT = Union(
   Literal(EthereumNetworks.xdc),
   Literal(EthereumNetworks.xdcapothem),
   Literal(EthereumNetworks.stabilityTestnet),
-  Literal(EthereumNetworks.gtn),
+  Literal(EthereumNetworks.stability),
   Literal(EthereumNetworks.local)
 );
 

--- a/src/records/dnsTxt.ts
+++ b/src/records/dnsTxt.ts
@@ -26,6 +26,7 @@ export enum EthereumNetworks {
   xdc = "50",
   xdcapothem = "51",
   stabilityTestnet = "20180427",
+  gtn = "101010",
 }
 
 export enum HederaNetworks {
@@ -46,6 +47,7 @@ export const EthereumNetworkIdT = Union(
   Literal(EthereumNetworks.xdc),
   Literal(EthereumNetworks.xdcapothem),
   Literal(EthereumNetworks.stabilityTestnet),
+  Literal(EthereumNetworks.gtn),
   Literal(EthereumNetworks.local)
 );
 


### PR DESCRIPTION
## Summary

This PR adds support for Stability's [Global Trust Network](https://github.com/stabilityprotocol/) network.

## Changes
- `dnsTxt.ts`

## Issues
NA