### PR TITLE
fix: ethereum txt record not valid for hedera

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -261,35 +261,42 @@ describe("getDocumentStoreRecords for Hedera", () => {
     {
       type: "openatts",
       net: "hedera",
-      netId: "296",
-      dnssec: false,
-      addr: "0x3DE43bfd3D771931E46CbBd4EDE0D3d95C85f81A",
-    },
-    {
+      netId: "295",
       addr: "0x222B69788e2e9B7FB93a3a0fE258D4604Dc7df21",
       dnssec: false,
-      net: "hedera",
-      netId: "295",
-      type: "openatts",
     },
     {
+      type: "openatts",
+      net: "hedera",
+      netId: "296",
+      addr: "0x222B69788e2e9B7FB93a3a0fE258D4604Dc7df21",
+      dnssec: false,
+    },
+    {
+      type: "openatts",
+      net: "hedera",
+      netId: "296",
+      addr: "0x3DE43bfd3D771931E46CbBd4EDE0D3d95C85f81A",
+      dnssec: false,
+    },
+    {
+      type: "openatts",
+      net: "hedera",
+      netId: "296",
       addr: "0xB9cf2eFcBeCdF96E6A7E46AECd79A784B41Bcf6B",
       dnssec: false,
-      net: "hedera",
-      netId: "296",
-      type: "openatts",
-    },
-    {
-      addr: "0x222B69788e2e9B7FB93a3a0fE258D4604Dc7df21",
-      dnssec: false,
-      net: "hedera",
-      netId: "296",
-      type: "openatts",
     },
   ];
 
   test("it should work with trustlv.org", async () => {
-    const records = await getDocumentStoreRecords("trustlv.org");
+    const records = (await getDocumentStoreRecords("trustlv.org")).sort((a, b) => {
+      if (a.netId < b.netId) return -1;
+      if (a.netId > b.netId) return 1;
+      if (a.addr < b.addr) return -1;
+      if (a.addr > b.addr) return 1;
+      return 0;
+    });
+
     expect(records).toStrictEqual(sampleDnsTextRecord);
   });
 });

--- a/src/records/dnsTxt.ts
+++ b/src/records/dnsTxt.ts
@@ -26,6 +26,8 @@ export enum EthereumNetworks {
   xdcapothem = "51",
   stabilityTestnet = "20180427",
   stability = "101010",
+  hedera = "295",
+  hederatestnet = "296",
 }
 
 export enum HederaNetworks {
@@ -46,7 +48,9 @@ export const EthereumNetworkIdT = Union(
   Literal(EthereumNetworks.xdcapothem),
   Literal(EthereumNetworks.stabilityTestnet),
   Literal(EthereumNetworks.stability),
-  Literal(EthereumNetworks.local)
+  Literal(EthereumNetworks.local),
+  Literal(EthereumNetworks.hedera),
+  Literal(EthereumNetworks.hederatestnet)
 );
 
 export const OpenAttestationDNSTextRecordT = Union(


### PR DESCRIPTION
## Summary

When verifying hedera documents, if the dns-txt record is `net=ethereum`, the verification will fail with invalid issuer identity as ethereum is not the valid `net` name for hedera

## Changes 

add hedera as valid ethereum network