### PR TITLE
feat: add AliDNS and Cloudflare DNS resolvers with corresponding tests

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,6 +1,14 @@
 import { setupServer, SetupServerApi } from "msw/node";
 import { http, HttpResponse } from "msw";
-import { CustomDnsResolver, getDocumentStoreRecords, queryDns, parseDocumentStoreResults, getDnsDidRecords } from ".";
+import {
+  aliDnsResolver,
+  cloudflareDnsResolver,
+  getDocumentStoreRecords,
+  getDnsDidRecords,
+  googleDnsResolver,
+  parseDocumentStoreResults,
+  queryDns,
+} from ".";
 import { DnsproveStatusCode } from "./common/error";
 
 describe("getCertStoreRecords", () => {
@@ -208,22 +216,7 @@ describe("queryDns", () => {
     Comment: "Response from 205.251.199.177.",
   };
 
-  const testDnsResolvers: CustomDnsResolver[] = [
-    async (domain) => {
-      const data = await fetch(`https://dns.google/resolve?name=${domain}&type=TXT`, {
-        method: "GET",
-      });
-
-      return data.json();
-    },
-    async (domain) => {
-      const data = await fetch(`https://cloudflare-dns.com/dns-query?name=${domain}&type=TXT`, {
-        method: "GET",
-        headers: { accept: "application/dns-json", contentType: "application/json", connection: "keep-alive" },
-      });
-      return data.json();
-    },
-  ];
+  const testDnsResolvers = [googleDnsResolver, cloudflareDnsResolver, aliDnsResolver];
 
   afterEach(() => {
     server.close();
@@ -270,14 +263,16 @@ describe("queryDns", () => {
       http.get("https://cloudflare-dns.com/dns-query", (_) => {
         return new HttpResponse(null, { status: 500 });
       }),
+      http.get("https://dns.alidns.com/resolve", (_) => {
+        return new HttpResponse(null, { status: 500 });
+      }),
     ];
     server = setupServer(...handlers);
     server.listen();
-    try {
-      await queryDns("https://donotuse.openattestation.com", testDnsResolvers);
-    } catch (e: any) {
-      expect(e.code).toStrictEqual(DnsproveStatusCode.IDNS_QUERY_ERROR_GENERAL);
-    }
+
+    await expect(queryDns("https://donotuse.openattestation.com", testDnsResolvers)).rejects.toMatchObject({
+      code: DnsproveStatusCode.IDNS_QUERY_ERROR_GENERAL,
+    });
   });
 });
 
@@ -319,6 +314,13 @@ describe("getDocumentStoreRecords for Astron", () => {
       net: "ethereum",
       netId: "1338",
       addr: "0x18bc0127Ae33389cD96593a1a612774fD14c0737",
+      dnssec: false,
+    },
+    {
+      type: "openatts",
+      net: "ethereum",
+      netId: "1338",
+      addr: "0x94FD21A026E29E0686583b8be71Cb28a8ca1A8d4",
       dnssec: false,
     },
     {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -255,6 +255,27 @@ describe("queryDns", () => {
     expect(sortedAnswer).toMatchObject(sampleResponse.Answer);
   });
 
+  test("Should fallback to third dns when first and second dns is down", async () => {
+    const handlers = [
+      http.get("https://dns.google/resolve", (_) => {
+        return new HttpResponse(null, { status: 500 });
+      }),
+      http.get("https://cloudflare-dns.com/dns-query", (_) => {
+        return new HttpResponse(null, { status: 500 });
+      }),
+      http.get("https://dns.alidns.com/resolve", (_) => {
+        return HttpResponse.json(sampleResponse);
+      }),
+    ];
+    server = setupServer(...handlers);
+    server.listen();
+
+    const records = await queryDns("https://donotuse.trustvc.io", testDnsResolvers);
+
+    const sortedAnswer = records?.Answer.sort((a, b) => a.data.localeCompare(b.data));
+    expect(sortedAnswer).toMatchObject(sampleResponse.Answer);
+  });
+
   test("Should throw error when all dns provided are down", async () => {
     const handlers = [
       http.get("https://dns.google/resolve", (_) => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -16,11 +16,11 @@ describe("getCertStoreRecords", () => {
     type: "openatts",
     net: "ethereum",
     netId: "3",
-    dnssec: true,
+    dnssec: false,
     addr: "0x2f60375e8144e16Adf1979936301D8341D58C36C",
   };
   test("it should work", async () => {
-    const records = await getDocumentStoreRecords("donotuse.openattestation.com");
+    const records = await getDocumentStoreRecords("donotuse.trustvc.io");
     expect(records).toStrictEqual([sampleDnsTextRecordWithDnssec]);
   });
 
@@ -35,14 +35,14 @@ describe("getCertStoreRecords", () => {
 
 describe("getDnsDidRecords", () => {
   test("it should work", async () => {
-    const records = await getDnsDidRecords("donotuse.openattestation.com");
+    const records = await getDnsDidRecords("donotuse.trustvc.io");
     expect(records).toStrictEqual([
       {
         type: "openatts",
         algorithm: "dns-did",
         publicKey: "did:ethr:0xE712878f6E8d5d4F9e87E10DA604F9cB564C9a89#controller",
         version: "1.0",
-        dnssec: true,
+        dnssec: false,
       },
     ]);
   });
@@ -185,29 +185,29 @@ describe("queryDns", () => {
     RA: true,
     AD: true,
     CD: false,
-    Question: [{ name: "donotuse.openattestation.com.", type: 16 }],
+    Question: [{ name: "donotuse.trustvc.io.", type: 16 }],
     Answer: [
       {
-        name: "donotuse.openattestation.com.",
+        name: "donotuse.trustvc.io.",
         type: 16,
         TTL: 300,
         data: "openatts a=dns-did; p=did:ethr:0xE712878f6E8d5d4F9e87E10DA604F9cB564C9a89#controller; v=1.0;",
       },
       {
-        name: "donotuse.openattestation.com.",
+        name: "donotuse.trustvc.io.",
         type: 16,
         TTL: 300,
         data:
           "openatts DO NOT ADD ANY RECORDS BEYOND THIS AS THIS DOMAIN IS USED FOR DNSPROVE NPM LIBRARY INTEGRATION TESTS",
       },
       {
-        name: "donotuse.openattestation.com.",
+        name: "donotuse.trustvc.io.",
         type: 16,
         TTL: 300,
         data: "openatts fooooooobarrrrrrrrr this entry exists to ensure validation works",
       },
       {
-        name: "donotuse.openattestation.com.",
+        name: "donotuse.trustvc.io.",
         type: 16,
         TTL: 300,
         data: "openatts net=ethereum netId=3 addr=0x2f60375e8144e16Adf1979936301D8341D58C36C",
@@ -232,7 +232,7 @@ describe("queryDns", () => {
     server = setupServer(...handlers);
     server.listen();
 
-    const records = await queryDns("https://donotuse.openattestation.com", testDnsResolvers);
+    const records = await queryDns("https://donotuse.trustvc.io", testDnsResolvers);
     const sortedAnswer = records?.Answer.sort((a, b) => a.data.localeCompare(b.data));
     expect(sortedAnswer).toMatchObject(sampleResponse.Answer);
   });
@@ -249,7 +249,7 @@ describe("queryDns", () => {
     server = setupServer(...handlers);
     server.listen();
 
-    const records = await queryDns("https://donotuse.openattestation.com", testDnsResolvers);
+    const records = await queryDns("https://donotuse.trustvc.io", testDnsResolvers);
 
     const sortedAnswer = records?.Answer.sort((a, b) => a.data.localeCompare(b.data));
     expect(sortedAnswer).toMatchObject(sampleResponse.Answer);
@@ -270,7 +270,7 @@ describe("queryDns", () => {
     server = setupServer(...handlers);
     server.listen();
 
-    await expect(queryDns("https://donotuse.openattestation.com", testDnsResolvers)).rejects.toMatchObject({
+    await expect(queryDns("https://donotuse.trustvc.io", testDnsResolvers)).rejects.toMatchObject({
       code: DnsproveStatusCode.IDNS_QUERY_ERROR_GENERAL,
     });
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { OpenAttestationDNSTextRecord, OpenAttestationDNSTextRecordT } from "./r
 import { OpenAttestationDnsDidRecord, OpenAttestationDnsDidRecordT } from "./records/dnsDid";
 import { getLogger } from "./util/logger";
 import { CodedError, DnsproveStatusCode } from "./common/error";
+import { aliDnsResolver, cloudflareDnsResolver, googleDnsResolver } from "./util/dns-resolvers";
 
 const { trace } = getLogger("index");
 
@@ -23,22 +24,7 @@ interface GenericObject {
 
 export type CustomDnsResolver = (domain: string) => Promise<IDNSQueryResponse>;
 
-export const defaultDnsResolvers: CustomDnsResolver[] = [
-  async (domain) => {
-    const data = await fetch(`https://dns.google/resolve?name=${domain}&type=TXT`, {
-      method: "GET",
-    });
-
-    return data.json();
-  },
-  async (domain) => {
-    const data = await fetch(`https://cloudflare-dns.com/dns-query?name=${domain}&type=TXT`, {
-      method: "GET",
-      headers: { accept: "application/dns-json", contentType: "application/json", connection: "keep-alive" },
-    });
-    return data.json();
-  },
-];
+export const defaultDnsResolvers: CustomDnsResolver[] = [googleDnsResolver, cloudflareDnsResolver, aliDnsResolver];
 
 /**
  * Returns true for strings that are openattestation records
@@ -115,8 +101,10 @@ export const parseOpenAttestationRecord = (record: string): GenericObject => {
   trace(`Parsing record: ${record}`);
   const keyValuePairs = record.trim().split(" "); // tokenize into key=value elements
   const recordObject = {} as GenericObject;
-  // @ts-ignore: we already checked for this token
-  recordObject.type = keyValuePairs.shift();
+  const typeToken = keyValuePairs.shift();
+  if (typeToken !== undefined) {
+    recordObject.type = typeToken;
+  }
   keyValuePairs.reduce<GenericObject>(addKeyValuePairToObject, recordObject);
   return recordObject;
 };
@@ -153,6 +141,7 @@ const parseOpenAttestationRecords = (recordSet: IDNSRecord[] = []): GenericObjec
 /**
  * Takes a DNS-TXT Record set and returns openattestation document store records if any
  * @param recordSet Refer to tests for examples
+ * @param dnssec Resolver AD (authenticated data) flag; applied as each record's `dnssec` field
  */
 export const parseDocumentStoreResults = (
   recordSet: IDNSRecord[] = [],
@@ -177,6 +166,7 @@ export const parseDnsDidResults = (recordSet: IDNSRecord[] = [], dnssec: boolean
 /**
  * Queries a given domain and parses the results to retrieve openattestation document store records if any
  * @param domain e.g: "example.openattestation.com"
+ * @param customDnsResolvers Optional resolver list; built-in HTTP DNS chain is used when omitted
  * @example
  * > getDocumentStoreRecords("example.openattestation.com")
  * > [ { type: 'openatts',
@@ -191,7 +181,7 @@ export const getDocumentStoreRecords = async (
 ): Promise<OpenAttestationDNSTextRecord[]> => {
   trace(`Received request to resolve ${domain}`);
 
-  const dnsResolvers = customDnsResolvers || defaultDnsResolvers;
+  const dnsResolvers = customDnsResolvers ?? defaultDnsResolvers;
 
   const results = await queryDns(domain, dnsResolvers);
   const answers = results.Answer || [];
@@ -207,7 +197,7 @@ export const getDnsDidRecords = async (
 ): Promise<OpenAttestationDnsDidRecord[]> => {
   trace(`Received request to resolve ${domain}`);
 
-  const dnsResolvers = customDnsResolvers || defaultDnsResolvers;
+  const dnsResolvers = customDnsResolvers ?? defaultDnsResolvers;
 
   const results = await queryDns(domain, dnsResolvers);
   const answers = results.Answer || [];
@@ -218,3 +208,4 @@ export const getDnsDidRecords = async (
 };
 
 export { OpenAttestationDNSTextRecord, OpenAttestationDnsDidRecord };
+export * from "./util/dns-resolvers";

--- a/src/util/dns-resolvers/ali-dns-resolver.ts
+++ b/src/util/dns-resolvers/ali-dns-resolver.ts
@@ -12,7 +12,7 @@ export const aliDnsResolver: CustomDnsResolver = async (domain) => {
   url.searchParams.set("name", domain);
   url.searchParams.set("type", ALI_DNS_TXT_QUERY_TYPE);
 
-  const res = await fetch(url, { method: "GET" });
+  const res = await fetch(url);
 
   if (!res.ok) {
     throw new Error(`Ali DNS request failed: HTTP ${res.status}`);

--- a/src/util/dns-resolvers/ali-dns-resolver.ts
+++ b/src/util/dns-resolvers/ali-dns-resolver.ts
@@ -1,0 +1,8 @@
+import type { CustomDnsResolver, IDNSQueryResponse } from "../..";
+
+export const aliDnsResolver: CustomDnsResolver = async (domain) => {
+  const res = await fetch(`https://dns.alidns.com/resolve?name=${domain}&type=16`, {
+    method: "GET",
+  });
+  return res.json() as Promise<IDNSQueryResponse>;
+};

--- a/src/util/dns-resolvers/ali-dns-resolver.ts
+++ b/src/util/dns-resolvers/ali-dns-resolver.ts
@@ -1,8 +1,15 @@
 import type { CustomDnsResolver, IDNSQueryResponse } from "../..";
 
 export const aliDnsResolver: CustomDnsResolver = async (domain) => {
-  const res = await fetch(`https://dns.alidns.com/resolve?name=${domain}&type=16`, {
-    method: "GET",
-  });
+  const url = new URL("https://dns.alidns.com/resolve");
+  url.searchParams.set("name", domain);
+  url.searchParams.set("type", "16");
+
+  const res = await fetch(url, { method: "GET" });
+
+  if (!res.ok) {
+    throw new Error(`Ali DNS request failed: HTTP ${res.status}`);
+  }
+
   return res.json() as Promise<IDNSQueryResponse>;
 };

--- a/src/util/dns-resolvers/ali-dns-resolver.ts
+++ b/src/util/dns-resolvers/ali-dns-resolver.ts
@@ -18,5 +18,12 @@ export const aliDnsResolver: CustomDnsResolver = async (domain) => {
     throw new Error(`Ali DNS request failed: HTTP ${res.status}`);
   }
 
-  return res.json() as Promise<IDNSQueryResponse>;
+  let data;
+  try {
+    data = await res.json();
+  } catch {
+    throw new Error("Failed to parse DNS response JSON");
+  }
+
+  return data as IDNSQueryResponse;
 };

--- a/src/util/dns-resolvers/ali-dns-resolver.ts
+++ b/src/util/dns-resolvers/ali-dns-resolver.ts
@@ -2,6 +2,11 @@ import type { CustomDnsResolver, IDNSQueryResponse } from "../..";
 
 export const aliDnsResolver: CustomDnsResolver = async (domain) => {
   const url = new URL("https://dns.alidns.com/resolve");
+
+  if (!domain) {
+    throw new Error("Domain is required");
+  }
+
   url.searchParams.set("name", domain);
   url.searchParams.set("type", "16");
 

--- a/src/util/dns-resolvers/ali-dns-resolver.ts
+++ b/src/util/dns-resolvers/ali-dns-resolver.ts
@@ -1,5 +1,7 @@
 import type { CustomDnsResolver, IDNSQueryResponse } from "../..";
 
+/** Ali DNS JSON API uses numeric RRTYPE; 16 = TXT */
+const ALI_DNS_TXT_QUERY_TYPE = "16";
 export const aliDnsResolver: CustomDnsResolver = async (domain) => {
   const url = new URL("https://dns.alidns.com/resolve");
 
@@ -8,7 +10,7 @@ export const aliDnsResolver: CustomDnsResolver = async (domain) => {
   }
 
   url.searchParams.set("name", domain);
-  url.searchParams.set("type", "16");
+  url.searchParams.set("type", ALI_DNS_TXT_QUERY_TYPE);
 
   const res = await fetch(url, { method: "GET" });
 

--- a/src/util/dns-resolvers/cloudflare-dns-resolver.ts
+++ b/src/util/dns-resolvers/cloudflare-dns-resolver.ts
@@ -19,5 +19,12 @@ export const cloudflareDnsResolver: CustomDnsResolver = async (domain) => {
     throw new Error(`Cloudflare DNS request failed: HTTP ${res.status}`);
   }
 
-  return res.json() as Promise<IDNSQueryResponse>;
+  let data;
+  try {
+    data = await res.json();
+  } catch {
+    throw new Error("Failed to parse DNS response JSON");
+  }
+
+  return data as IDNSQueryResponse;
 };

--- a/src/util/dns-resolvers/cloudflare-dns-resolver.ts
+++ b/src/util/dns-resolvers/cloudflare-dns-resolver.ts
@@ -1,9 +1,18 @@
 import type { CustomDnsResolver, IDNSQueryResponse } from "../..";
 
 export const cloudflareDnsResolver: CustomDnsResolver = async (domain) => {
-  const res = await fetch(`https://cloudflare-dns.com/dns-query?name=${domain}&type=TXT`, {
+  const url = new URL("https://cloudflare-dns.com/dns-query");
+  url.searchParams.set("name", domain);
+  url.searchParams.set("type", "TXT");
+
+  const res = await fetch(url, {
     method: "GET",
-    headers: { accept: "application/dns-json", contentType: "application/json", connection: "keep-alive" },
+    headers: { Accept: "application/dns-json" },
   });
+
+  if (!res.ok) {
+    throw new Error(`Cloudflare DNS request failed: HTTP ${res.status}`);
+  }
+
   return res.json() as Promise<IDNSQueryResponse>;
 };

--- a/src/util/dns-resolvers/cloudflare-dns-resolver.ts
+++ b/src/util/dns-resolvers/cloudflare-dns-resolver.ts
@@ -11,7 +11,6 @@ export const cloudflareDnsResolver: CustomDnsResolver = async (domain) => {
   url.searchParams.set("type", "TXT");
 
   const res = await fetch(url, {
-    method: "GET",
     headers: { Accept: "application/dns-json" },
   });
 

--- a/src/util/dns-resolvers/cloudflare-dns-resolver.ts
+++ b/src/util/dns-resolvers/cloudflare-dns-resolver.ts
@@ -1,0 +1,9 @@
+import type { CustomDnsResolver, IDNSQueryResponse } from "../..";
+
+export const cloudflareDnsResolver: CustomDnsResolver = async (domain) => {
+  const res = await fetch(`https://cloudflare-dns.com/dns-query?name=${domain}&type=TXT`, {
+    method: "GET",
+    headers: { accept: "application/dns-json", contentType: "application/json", connection: "keep-alive" },
+  });
+  return res.json() as Promise<IDNSQueryResponse>;
+};

--- a/src/util/dns-resolvers/cloudflare-dns-resolver.ts
+++ b/src/util/dns-resolvers/cloudflare-dns-resolver.ts
@@ -2,6 +2,11 @@ import type { CustomDnsResolver, IDNSQueryResponse } from "../..";
 
 export const cloudflareDnsResolver: CustomDnsResolver = async (domain) => {
   const url = new URL("https://cloudflare-dns.com/dns-query");
+
+  if (!domain) {
+    throw new Error("Domain is required");
+  }
+
   url.searchParams.set("name", domain);
   url.searchParams.set("type", "TXT");
 

--- a/src/util/dns-resolvers/dns-resolvers.test.ts
+++ b/src/util/dns-resolvers/dns-resolvers.test.ts
@@ -1,0 +1,87 @@
+import { setupServer, SetupServerApi } from "msw/node";
+import { http, HttpResponse } from "msw";
+import { aliDnsResolver } from "./ali-dns-resolver";
+import { cloudflareDnsResolver } from "./cloudflare-dns-resolver";
+import { googleDnsResolver } from "./google-dns-resolver";
+
+const emptyDnsJson = {
+  Status: 0,
+  TC: false,
+  RD: true,
+  RA: true,
+  AD: false,
+  CD: false,
+  Answer: [] as [],
+};
+
+describe("googleDnsResolver", () => {
+  let server: SetupServerApi;
+
+  afterEach(() => {
+    server.close();
+  });
+
+  test("requests Google DNS JSON with name and TXT type", async () => {
+    server = setupServer(
+      http.get("https://dns.google/resolve", ({ request }) => {
+        const url = new URL(request.url);
+        expect(url.searchParams.get("name")).toBe("my.domain.test");
+        expect(url.searchParams.get("type")).toBe("TXT");
+        return HttpResponse.json(emptyDnsJson);
+      })
+    );
+    server.listen();
+
+    const out = await googleDnsResolver("my.domain.test");
+    expect(out).toMatchObject({ Status: 0, Answer: [] });
+  });
+});
+
+describe("cloudflareDnsResolver", () => {
+  let server: SetupServerApi;
+
+  afterEach(() => {
+    server.close();
+  });
+
+  test("requests Cloudflare DNS JSON with name, TXT type, and expected headers", async () => {
+    server = setupServer(
+      http.get("https://cloudflare-dns.com/dns-query", ({ request }) => {
+        const url = new URL(request.url);
+        expect(url.searchParams.get("name")).toBe("cf.example.test");
+        expect(url.searchParams.get("type")).toBe("TXT");
+        expect(request.headers.get("accept")).toBe("application/dns-json");
+        expect(request.headers.get("connection")).toBe("keep-alive");
+        expect(request.headers.get("contenttype")).toBe("application/json");
+        return HttpResponse.json(emptyDnsJson);
+      })
+    );
+    server.listen();
+
+    const out = await cloudflareDnsResolver("cf.example.test");
+    expect(out).toMatchObject({ Status: 0, Answer: [] });
+  });
+});
+
+describe("aliDnsResolver", () => {
+  let server: SetupServerApi;
+
+  afterEach(() => {
+    server.close();
+  });
+
+  test("requests Ali DNS JSON with name and type 16 (TXT)", async () => {
+    server = setupServer(
+      http.get("https://dns.alidns.com/resolve", ({ request }) => {
+        const url = new URL(request.url);
+        expect(url.searchParams.get("name")).toBe("ali.example.test");
+        expect(url.searchParams.get("type")).toBe("16");
+        return HttpResponse.json(emptyDnsJson);
+      })
+    );
+    server.listen();
+
+    const out = await aliDnsResolver("ali.example.test");
+    expect(out).toMatchObject({ Status: 0, Answer: [] });
+  });
+});

--- a/src/util/dns-resolvers/dns-resolvers.test.ts
+++ b/src/util/dns-resolvers/dns-resolvers.test.ts
@@ -37,9 +37,7 @@ describe("googleDnsResolver", () => {
   });
 
   test("throws when Google DNS returns non-2xx", async () => {
-    server = setupServer(
-      http.get("https://dns.google/resolve", () => new HttpResponse(null, { status: 503 }))
-    );
+    server = setupServer(http.get("https://dns.google/resolve", () => new HttpResponse(null, { status: 503 })));
     server.listen();
 
     await expect(googleDnsResolver("my.domain.test")).rejects.toThrow(/HTTP 503/);
@@ -110,9 +108,7 @@ describe("aliDnsResolver", () => {
   });
 
   test("throws when Ali DNS returns non-2xx", async () => {
-    server = setupServer(
-      http.get("https://dns.alidns.com/resolve", () => new HttpResponse(null, { status: 503 }))
-    );
+    server = setupServer(http.get("https://dns.alidns.com/resolve", () => new HttpResponse(null, { status: 503 })));
     server.listen();
 
     await expect(aliDnsResolver("ali.example.test")).rejects.toThrow(/HTTP 503/);

--- a/src/util/dns-resolvers/dns-resolvers.test.ts
+++ b/src/util/dns-resolvers/dns-resolvers.test.ts
@@ -21,19 +21,28 @@ describe("googleDnsResolver", () => {
     server.close();
   });
 
-  test("requests Google DNS JSON with name and TXT type", async () => {
+  test("requests Google DNS JSON with name, TXT type, and encoded query", async () => {
     server = setupServer(
       http.get("https://dns.google/resolve", ({ request }) => {
         const url = new URL(request.url);
-        expect(url.searchParams.get("name")).toBe("my.domain.test");
+        expect(url.searchParams.get("name")).toBe("my domain.test");
         expect(url.searchParams.get("type")).toBe("TXT");
         return HttpResponse.json(emptyDnsJson);
       })
     );
     server.listen();
 
-    const out = await googleDnsResolver("my.domain.test");
+    const out = await googleDnsResolver("my domain.test");
     expect(out).toMatchObject({ Status: 0, Answer: [] });
+  });
+
+  test("throws when Google DNS returns non-2xx", async () => {
+    server = setupServer(
+      http.get("https://dns.google/resolve", () => new HttpResponse(null, { status: 503 }))
+    );
+    server.listen();
+
+    await expect(googleDnsResolver("my.domain.test")).rejects.toThrow(/HTTP 503/);
   });
 });
 
@@ -44,22 +53,29 @@ describe("cloudflareDnsResolver", () => {
     server.close();
   });
 
-  test("requests Cloudflare DNS JSON with name, TXT type, and expected headers", async () => {
+  test("requests Cloudflare DNS JSON with name, TXT type, Accept header, and encoded query", async () => {
     server = setupServer(
       http.get("https://cloudflare-dns.com/dns-query", ({ request }) => {
         const url = new URL(request.url);
-        expect(url.searchParams.get("name")).toBe("cf.example.test");
+        expect(url.searchParams.get("name")).toBe("cf example.test");
         expect(url.searchParams.get("type")).toBe("TXT");
         expect(request.headers.get("accept")).toBe("application/dns-json");
-        expect(request.headers.get("connection")).toBe("keep-alive");
-        expect(request.headers.get("contenttype")).toBe("application/json");
         return HttpResponse.json(emptyDnsJson);
       })
     );
     server.listen();
 
-    const out = await cloudflareDnsResolver("cf.example.test");
+    const out = await cloudflareDnsResolver("cf example.test");
     expect(out).toMatchObject({ Status: 0, Answer: [] });
+  });
+
+  test("throws when Cloudflare DNS returns non-2xx", async () => {
+    server = setupServer(
+      http.get("https://cloudflare-dns.com/dns-query", () => new HttpResponse(null, { status: 502 }))
+    );
+    server.listen();
+
+    await expect(cloudflareDnsResolver("cf.example.test")).rejects.toThrow(/HTTP 502/);
   });
 });
 
@@ -70,18 +86,27 @@ describe("aliDnsResolver", () => {
     server.close();
   });
 
-  test("requests Ali DNS JSON with name and type 16 (TXT)", async () => {
+  test("requests Ali DNS JSON with name, type 16 (TXT), and encoded query", async () => {
     server = setupServer(
       http.get("https://dns.alidns.com/resolve", ({ request }) => {
         const url = new URL(request.url);
-        expect(url.searchParams.get("name")).toBe("ali.example.test");
+        expect(url.searchParams.get("name")).toBe("ali example.test");
         expect(url.searchParams.get("type")).toBe("16");
         return HttpResponse.json(emptyDnsJson);
       })
     );
     server.listen();
 
-    const out = await aliDnsResolver("ali.example.test");
+    const out = await aliDnsResolver("ali example.test");
     expect(out).toMatchObject({ Status: 0, Answer: [] });
+  });
+
+  test("throws when Ali DNS returns non-2xx", async () => {
+    server = setupServer(
+      http.get("https://dns.alidns.com/resolve", () => new HttpResponse(null, { status: 503 }))
+    );
+    server.listen();
+
+    await expect(aliDnsResolver("ali.example.test")).rejects.toThrow(/HTTP 503/);
   });
 });

--- a/src/util/dns-resolvers/dns-resolvers.test.ts
+++ b/src/util/dns-resolvers/dns-resolvers.test.ts
@@ -15,10 +15,10 @@ const emptyDnsJson = {
 };
 
 describe("googleDnsResolver", () => {
-  let server: SetupServerApi;
+  let server: SetupServerApi | undefined;
 
   afterEach(() => {
-    server.close();
+    server?.close();
   });
 
   test("requests Google DNS JSON with name, TXT type, and encoded query", async () => {
@@ -44,13 +44,17 @@ describe("googleDnsResolver", () => {
 
     await expect(googleDnsResolver("my.domain.test")).rejects.toThrow(/HTTP 503/);
   });
+
+  test("throws when domain is empty", async () => {
+    await expect(googleDnsResolver("")).rejects.toThrow("Domain is required");
+  });
 });
 
 describe("cloudflareDnsResolver", () => {
-  let server: SetupServerApi;
+  let server: SetupServerApi | undefined;
 
   afterEach(() => {
-    server.close();
+    server?.close();
   });
 
   test("requests Cloudflare DNS JSON with name, TXT type, Accept header, and encoded query", async () => {
@@ -77,13 +81,17 @@ describe("cloudflareDnsResolver", () => {
 
     await expect(cloudflareDnsResolver("cf.example.test")).rejects.toThrow(/HTTP 502/);
   });
+
+  test("throws when domain is empty", async () => {
+    await expect(cloudflareDnsResolver("")).rejects.toThrow("Domain is required");
+  });
 });
 
 describe("aliDnsResolver", () => {
-  let server: SetupServerApi;
+  let server: SetupServerApi | undefined;
 
   afterEach(() => {
-    server.close();
+    server?.close();
   });
 
   test("requests Ali DNS JSON with name, type 16 (TXT), and encoded query", async () => {
@@ -108,5 +116,9 @@ describe("aliDnsResolver", () => {
     server.listen();
 
     await expect(aliDnsResolver("ali.example.test")).rejects.toThrow(/HTTP 503/);
+  });
+
+  test("throws when domain is empty", async () => {
+    await expect(aliDnsResolver("")).rejects.toThrow("Domain is required");
   });
 });

--- a/src/util/dns-resolvers/google-dns-resolver.ts
+++ b/src/util/dns-resolvers/google-dns-resolver.ts
@@ -10,7 +10,7 @@ export const googleDnsResolver: CustomDnsResolver = async (domain) => {
   url.searchParams.set("name", domain);
   url.searchParams.set("type", "TXT");
 
-  const res = await fetch(url, { method: "GET" });
+  const res = await fetch(url);
 
   if (!res.ok) {
     throw new Error(`Google DNS request failed: HTTP ${res.status}`);

--- a/src/util/dns-resolvers/google-dns-resolver.ts
+++ b/src/util/dns-resolvers/google-dns-resolver.ts
@@ -1,8 +1,15 @@
 import type { CustomDnsResolver, IDNSQueryResponse } from "../..";
 
 export const googleDnsResolver: CustomDnsResolver = async (domain) => {
-  const res = await fetch(`https://dns.google/resolve?name=${domain}&type=TXT`, {
-    method: "GET",
-  });
+  const url = new URL("https://dns.google/resolve");
+  url.searchParams.set("name", domain);
+  url.searchParams.set("type", "TXT");
+
+  const res = await fetch(url, { method: "GET" });
+
+  if (!res.ok) {
+    throw new Error(`Google DNS request failed: HTTP ${res.status}`);
+  }
+
   return res.json() as Promise<IDNSQueryResponse>;
 };

--- a/src/util/dns-resolvers/google-dns-resolver.ts
+++ b/src/util/dns-resolvers/google-dns-resolver.ts
@@ -1,0 +1,8 @@
+import type { CustomDnsResolver, IDNSQueryResponse } from "../..";
+
+export const googleDnsResolver: CustomDnsResolver = async (domain) => {
+  const res = await fetch(`https://dns.google/resolve?name=${domain}&type=TXT`, {
+    method: "GET",
+  });
+  return res.json() as Promise<IDNSQueryResponse>;
+};

--- a/src/util/dns-resolvers/google-dns-resolver.ts
+++ b/src/util/dns-resolvers/google-dns-resolver.ts
@@ -16,5 +16,12 @@ export const googleDnsResolver: CustomDnsResolver = async (domain) => {
     throw new Error(`Google DNS request failed: HTTP ${res.status}`);
   }
 
-  return res.json() as Promise<IDNSQueryResponse>;
+  let data;
+  try {
+    data = await res.json();
+  } catch {
+    throw new Error("Failed to parse DNS response JSON");
+  }
+
+  return data as IDNSQueryResponse;
 };

--- a/src/util/dns-resolvers/google-dns-resolver.ts
+++ b/src/util/dns-resolvers/google-dns-resolver.ts
@@ -2,6 +2,11 @@ import type { CustomDnsResolver, IDNSQueryResponse } from "../..";
 
 export const googleDnsResolver: CustomDnsResolver = async (domain) => {
   const url = new URL("https://dns.google/resolve");
+
+  if (!domain) {
+    throw new Error("Domain is required");
+  }
+
   url.searchParams.set("name", domain);
   url.searchParams.set("type", "TXT");
 

--- a/src/util/dns-resolvers/index.ts
+++ b/src/util/dns-resolvers/index.ts
@@ -1,0 +1,3 @@
+export * from "./google-dns-resolver";
+export * from "./cloudflare-dns-resolver";
+export * from "./ali-dns-resolver";


### PR DESCRIPTION
This pull request refactors DNS resolver logic by modularizing and expanding support for multiple public DNS-over-HTTPS providers. It introduces dedicated resolver functions for Google, Cloudflare, and AliDNS, updates the default resolver chain to include all three, and improves test coverage for these resolvers. Additionally, minor improvements were made to parsing and documentation.

**DNS Resolver Refactoring and Expansion:**

* Added separate resolver implementations for Google, Cloudflare, and AliDNS in the new `src/util/dns-resolvers` directory, each encapsulating the logic for querying their respective public DNS-over-HTTPS endpoints. [[1]](diffhunk://#diff-2444c0c3873e3ffe73b5b455f004d11636dfe0742dd0efd92f67d339c3fb1450R1-R8) [[2]](diffhunk://#diff-e5f0697e42099d4a267c0b8fad699a6cc629f2c4add42958b04ae4769ee276c6R1-R9) [[3]](diffhunk://#diff-20534843839a76d122780843926c76f51d0f17bac3e52e18c3578f02f1706f5aR1-R8)
* Updated the default resolver chain in `index.ts` to use the new resolver functions, now supporting Google, Cloudflare, and AliDNS by default.
* Exported all DNS resolver utilities from a new `src/util/dns-resolvers/index.ts` barrel file for easier imports. [[1]](diffhunk://#diff-73528f51522c24a0444f04af76cf7e22d028758495b802437e6a1478c09ca0dfR1-R3) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R211)

**Testing Improvements:**

* Added comprehensive tests for each DNS resolver to verify correct request construction and response handling, using MSW for HTTP mocking.
* Updated existing tests to use the new resolver functions instead of inlined resolver implementations. [[1]](diffhunk://#diff-258035e5968f6bf645400d417f310218d7d9a9a10606a3c34e7f55db193f58f3L3-R11) [[2]](diffhunk://#diff-258035e5968f6bf645400d417f310218d7d9a9a10606a3c34e7f55db193f58f3L211-R219) [[3]](diffhunk://#diff-258035e5968f6bf645400d417f310218d7d9a9a10606a3c34e7f55db193f58f3R266-R275)

**Minor Improvements:**

* Improved parsing logic in `parseOpenAttestationRecord` to better handle missing type tokens.
* Enhanced documentation for several functions, clarifying parameter usage and expected behavior. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R144) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R169)
* Changed fallback logic for custom resolvers from `||` to `??` for better handling of falsy values. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L194-R184) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L210-R200)

These changes make the DNS resolution logic more modular, robust, and easier to extend or test.

**Reference**

The implementation is based off the PR made in the Open-Attestation DNS Prove repo: https://github.com/Open-Attestation/dnsprove/pull/61/changes#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a third DNS resolver option and re-exported resolver utilities for direct use.

* **Bug Fixes**
  * Honor an explicitly provided empty resolver list.
  * Safer record parsing and more consistent DNSSEC/response expectations.
  * Included the new resolver in multi-resolver failure handling.

* **Tests**
  * Expanded resolver tests and mocks for success, HTTP errors, and empty-domain inputs; updated test domains and expected responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->