### PR TITLE
feat: add Mantle and MantleTestnet to EthereumNetworks enum

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -165,6 +165,50 @@ describe("parseDocumentStoreResults", () => {
     ];
     expect(parseDocumentStoreResults(sampleRecord, true)).toStrictEqual([]);
   });
+
+  test("it should accept Mantle mainnet (netId 5000)", () => {
+    const addr = "0x2f60375e8144e16Adf1979936301D8341D58C36C";
+    const sampleRecord = [
+      {
+        name: "example.example.com.",
+        type: 16,
+        TTL: 110,
+        data: `"openatts net=ethereum netId=5000 addr=${addr}"`,
+        dnssec: false,
+      },
+    ];
+    expect(parseDocumentStoreResults(sampleRecord, false)).toStrictEqual([
+      {
+        type: "openatts",
+        net: "ethereum",
+        netId: "5000",
+        addr,
+        dnssec: false,
+      },
+    ]);
+  });
+
+  test("it should accept Mantle testnet (netId 5003)", () => {
+    const addr = "0x2f60375e8144e16Adf1979936301D8341D58C36C";
+    const sampleRecord = [
+      {
+        name: "example.example.com.",
+        type: 16,
+        TTL: 110,
+        data: `"openatts net=ethereum netId=5003 addr=${addr}"`,
+        dnssec: false,
+      },
+    ];
+    expect(parseDocumentStoreResults(sampleRecord, false)).toStrictEqual([
+      {
+        type: "openatts",
+        net: "ethereum",
+        netId: "5003",
+        addr,
+        dnssec: false,
+      },
+    ]);
+  });
 });
 
 describe("queryDns", () => {
@@ -319,6 +363,13 @@ describe("getDocumentStoreRecords for Astron", () => {
       net: "ethereum",
       netId: "1338",
       addr: "0x18bc0127Ae33389cD96593a1a612774fD14c0737",
+      dnssec: false,
+    },
+    {
+      type: "openatts",
+      net: "ethereum",
+      netId: "1338",
+      addr: "0x94FD21A026E29E0686583b8be71Cb28a8ca1A8d4",
       dnssec: false,
     },
     {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -174,7 +174,7 @@ describe("parseDocumentStoreResults", () => {
     expect(parseDocumentStoreResults(sampleRecord, true)).toStrictEqual([]);
   });
 
-  test("it should accept Mantle mainnet (netId 5000)", () => {
+  test("it should accept any numeric netId (e.g. Mantle mainnet 5000)", () => {
     const addr = "0x2f60375e8144e16Adf1979936301D8341D58C36C";
     const sampleRecord = [
       {
@@ -196,14 +196,14 @@ describe("parseDocumentStoreResults", () => {
     ]);
   });
 
-  test("it should accept Mantle testnet (netId 5003)", () => {
+  test("it should accept an arbitrary previously-unknown numeric netId", () => {
     const addr = "0x2f60375e8144e16Adf1979936301D8341D58C36C";
     const sampleRecord = [
       {
         name: "example.example.com.",
         type: 16,
         TTL: 110,
-        data: `"openatts net=ethereum netId=5003 addr=${addr}"`,
+        data: `"openatts net=ethereum netId=99999 addr=${addr}"`,
         dnssec: false,
       },
     ];
@@ -211,11 +211,37 @@ describe("parseDocumentStoreResults", () => {
       {
         type: "openatts",
         net: "ethereum",
-        netId: "5003",
+        netId: "99999",
         addr,
         dnssec: false,
       },
     ]);
+  });
+
+  test("it should reject a non-numeric netId", () => {
+    const sampleRecord = [
+      {
+        name: "example.example.com.",
+        type: 16,
+        TTL: 110,
+        data: '"openatts net=ethereum netId=abc addr=0x2f60375e8144e16Adf1979936301D8341D58C36C"',
+        dnssec: false,
+      },
+    ];
+    expect(parseDocumentStoreResults(sampleRecord, false)).toStrictEqual([]);
+  });
+
+  test("it should reject an alphanumeric netId", () => {
+    const sampleRecord = [
+      {
+        name: "example.example.com.",
+        type: 16,
+        TTL: 110,
+        data: '"openatts net=ethereum netId=1abc addr=0x2f60375e8144e16Adf1979936301D8341D58C36C"',
+        dnssec: false,
+      },
+    ];
+    expect(parseDocumentStoreResults(sampleRecord, false)).toStrictEqual([]);
   });
 });
 

--- a/src/records/dnsTxt.ts
+++ b/src/records/dnsTxt.ts
@@ -23,6 +23,8 @@ export enum EthereumNetworks {
   stability = "101010",
   astronTestnet = "21002",
   astron = "1338",
+  mantle = "5000",
+  mantleTestnet = "5003",
 }
 
 export const EthereumNetworkIdT = Union(
@@ -39,7 +41,9 @@ export const EthereumNetworkIdT = Union(
   Literal(EthereumNetworks.stability),
   Literal(EthereumNetworks.local),
   Literal(EthereumNetworks.astronTestnet),
-  Literal(EthereumNetworks.astron)
+  Literal(EthereumNetworks.astron),
+  Literal(EthereumNetworks.mantle),
+  Literal(EthereumNetworks.mantleTestnet)
 );
 
 export const OpenAttestationDNSTextRecordT = Record({

--- a/src/records/dnsTxt.ts
+++ b/src/records/dnsTxt.ts
@@ -1,4 +1,4 @@
-import { Static, Boolean, String, Literal, Record, Union, Partial } from "runtypes";
+import { Static, Boolean, String, Literal, Record, Partial } from "runtypes";
 
 export const RecordTypesT = Literal("openatts");
 
@@ -8,42 +8,8 @@ export const EthereumAddressT = String.withConstraint((maybeAddress: string) => 
   return /0x[a-fA-F0-9]{40}/.test(maybeAddress) || `${maybeAddress} is not a valid ethereum address`;
 });
 
-export enum EthereumNetworks {
-  homestead = "1",
-  ropsten = "3",
-  rinkeby = "4",
-  goerli = "5",
-  sepolia = "11155111",
-  polygon = "137",
-  polygonAmoy = "80002",
-  local = "1337",
-  xdc = "50",
-  xdcapothem = "51",
-  stabilityTestnet = "20180427",
-  stability = "101010",
-  astronTestnet = "21002",
-  astron = "1338",
-  mantle = "5000",
-  mantleTestnet = "5003",
-}
-
-export const EthereumNetworkIdT = Union(
-  Literal(EthereumNetworks.homestead),
-  Literal(EthereumNetworks.ropsten),
-  Literal(EthereumNetworks.rinkeby),
-  Literal(EthereumNetworks.goerli),
-  Literal(EthereumNetworks.sepolia),
-  Literal(EthereumNetworks.polygon),
-  Literal(EthereumNetworks.polygonAmoy),
-  Literal(EthereumNetworks.xdc),
-  Literal(EthereumNetworks.xdcapothem),
-  Literal(EthereumNetworks.stabilityTestnet),
-  Literal(EthereumNetworks.stability),
-  Literal(EthereumNetworks.local),
-  Literal(EthereumNetworks.astronTestnet),
-  Literal(EthereumNetworks.astron),
-  Literal(EthereumNetworks.mantle),
-  Literal(EthereumNetworks.mantleTestnet)
+export const EthereumNetworkIdT = String.withConstraint(
+  (maybeNetId: string) => /^\d+$/.test(maybeNetId) || `${maybeNetId} is not a valid numeric network id`
 );
 
 export const OpenAttestationDNSTextRecordT = Record({


### PR DESCRIPTION
This pull request adds support for the Mantle mainnet and testnet Ethereum networks throughout the codebase. The changes ensure that Mantle networks (netId 5000 and 5003) are recognized and properly handled in both the core logic and the test suite.

**Mantle network support:**

* Added `mantle` (netId 5000) and `mantleTestnet` (netId 5003) to the `EthereumNetworks` enum in `dnsTxt.ts`, enabling recognition of these networks in the application logic.
* Updated the `EthereumNetworkIdT` union type to include Mantle mainnet and testnet, ensuring type safety and validation for these new network IDs.

**Testing enhancements:**

* Added unit tests in `index.test.ts` to verify that Mantle mainnet and testnet records are accepted by `parseDocumentStoreResults`.
* Added a new Astron record to the expected results in the `getDocumentStoreRecords for Astron` test, likely to ensure comprehensive coverage for multiple networks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DNS TXT parsing now accepts any numeric chain/network ID (enabling support for networks like Mantle mainnet/testnet).

* **Tests**
  * Added unit tests ensuring network IDs in DNS TXT records are strictly numeric (accepted) and that non-numeric or alphanumeric IDs are rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->