### PR TITLE
fix: merge multi-endpoint AliDNS queries to recover silently truncated TXT records

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -336,6 +336,12 @@ describe("queryDns", () => {
       http.get("https://dns.alidns.com/resolve", (_) => {
         return HttpResponse.json(sampleResponse);
       }),
+      http.get("https://223.5.5.5/resolve", (_) => {
+        return HttpResponse.json(sampleResponse);
+      }),
+      http.get("https://223.6.6.6/resolve", (_) => {
+        return HttpResponse.json(sampleResponse);
+      }),
     ];
     server = setupServer(...handlers);
     server.listen();
@@ -355,6 +361,12 @@ describe("queryDns", () => {
         return new HttpResponse(null, { status: 500 });
       }),
       http.get("https://dns.alidns.com/resolve", (_) => {
+        return new HttpResponse(null, { status: 500 });
+      }),
+      http.get("https://223.5.5.5/resolve", (_) => {
+        return new HttpResponse(null, { status: 500 });
+      }),
+      http.get("https://223.6.6.6/resolve", (_) => {
         return new HttpResponse(null, { status: 500 });
       }),
     ];

--- a/src/util/dns-resolvers/ali-dns-resolver.ts
+++ b/src/util/dns-resolvers/ali-dns-resolver.ts
@@ -1,29 +1,92 @@
-import type { CustomDnsResolver, IDNSQueryResponse } from "../..";
+import type { CustomDnsResolver, IDNSQueryResponse, IDNSRecord } from "../..";
 
 /** Ali DNS JSON API uses numeric RRTYPE; 16 = TXT */
 const ALI_DNS_TXT_QUERY_TYPE = "16";
-export const aliDnsResolver: CustomDnsResolver = async (domain) => {
-  const url = new URL("https://dns.alidns.com/resolve");
+const ALI_DNS_QUERY_TIMEOUT_MS = 10_000;
 
+/**
+ * Ali DNS edge caches hold partial snapshots of larger TXT record sets while
+ * reporting TC: false, so a single query can silently miss records. The same
+ * DoH service is exposed on three hosts (each with its own cache, all with
+ * CORS `*`), and the cache is additionally keyed on the edns_client_subnet
+ * parameter — so querying several host/ECS combinations and merging the
+ * answers recovers the complete record set.
+ */
+const ALI_DNS_QUERY_VARIANTS: { host: string; ecs?: string }[] = [
+  { host: "dns.alidns.com" },
+  { host: "223.5.5.5" },
+  { host: "223.6.6.6" },
+  { host: "223.5.5.5", ecs: "1.2.3.0/24" },
+  { host: "223.6.6.6", ecs: "202.96.209.0/24" },
+];
+
+const queryAliDnsVariant = async (
+  variant: { host: string; ecs?: string },
+  domain: string
+): Promise<IDNSQueryResponse> => {
+  const url = new URL(`https://${variant.host}/resolve`);
+  url.searchParams.set("name", domain);
+  url.searchParams.set("type", ALI_DNS_TXT_QUERY_TYPE);
+  if (variant.ecs) {
+    url.searchParams.set("edns_client_subnet", variant.ecs);
+  }
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), ALI_DNS_QUERY_TIMEOUT_MS);
+  try {
+    const res = await fetch(url, { signal: controller.signal });
+
+    if (!res.ok) {
+      throw new Error(`Ali DNS request failed: HTTP ${res.status}`);
+    }
+
+    try {
+      return (await res.json()) as IDNSQueryResponse;
+    } catch {
+      throw new Error("Failed to parse DNS response JSON");
+    }
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
+export const aliDnsResolver: CustomDnsResolver = async (domain) => {
   if (!domain) {
     throw new Error("Domain is required");
   }
 
-  url.searchParams.set("name", domain);
-  url.searchParams.set("type", ALI_DNS_TXT_QUERY_TYPE);
+  const errors: unknown[] = [];
+  const results = await Promise.all(
+    ALI_DNS_QUERY_VARIANTS.map(async (variant) => {
+      try {
+        return await queryAliDnsVariant(variant, domain);
+      } catch (error) {
+        errors.push(error);
+        return undefined;
+      }
+    })
+  );
+  const responses = results.filter((result): result is IDNSQueryResponse => result !== undefined);
 
-  const res = await fetch(url);
-
-  if (!res.ok) {
-    throw new Error(`Ali DNS request failed: HTTP ${res.status}`);
+  if (responses.length === 0) {
+    throw errors[0] instanceof Error ? errors[0] : new Error(String(errors[0]));
   }
 
-  let data;
-  try {
-    data = await res.json();
-  } catch {
-    throw new Error("Failed to parse DNS response JSON");
-  }
+  const seen = new Set<string>();
+  const mergedAnswers: IDNSRecord[] = [];
+  responses.forEach((response) => {
+    (response.Answer || []).forEach((record) => {
+      const key = `${record.name}|${record.type}|${record.data}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        mergedAnswers.push(record);
+      }
+    });
+  });
 
-  return data as IDNSQueryResponse;
+  return {
+    ...responses[0],
+    AD: responses.every((response) => response.AD),
+    Answer: mergedAnswers,
+  };
 };

--- a/src/util/dns-resolvers/ali-dns-resolver.ts
+++ b/src/util/dns-resolvers/ali-dns-resolver.ts
@@ -1,34 +1,45 @@
 import type { CustomDnsResolver, IDNSQueryResponse, IDNSRecord } from "../..";
+import { getLogger } from "../logger";
+
+const { trace, error: logError } = getLogger("ali-dns-resolver");
 
 /** Ali DNS JSON API uses numeric RRTYPE; 16 = TXT */
 const ALI_DNS_TXT_QUERY_TYPE = "16";
 const ALI_DNS_QUERY_TIMEOUT_MS = 10_000;
 
 /**
- * Ali DNS edge caches hold partial snapshots of larger TXT record sets while
- * reporting TC: false, so a single query can silently miss records. The same
- * DoH service is exposed on three hosts (each with its own cache, all with
- * CORS `*`), and the cache is additionally keyed on the edns_client_subnet
- * parameter — so querying several host/ECS combinations and merging the
- * answers recovers the complete record set.
+ * Ali DNS caps every response at roughly 12-14 TXT records regardless of the
+ * advertised EDNS buffer size, while reporting TC: false — so a single query
+ * silently misses records on larger record sets. The same DoH service is
+ * exposed on three hosts (each with its own cache, all with CORS `*`), and
+ * the cache is additionally keyed on the edns_client_subnet (ECS) parameter,
+ * so each host/ECS combination yields a different partial window onto the
+ * record set. The resolver queries in waves of three (one per host, all
+ * sharing that wave's ECS value) and merges the deduplicated answers,
+ * stopping once the merged set stops growing.
  */
-const ALI_DNS_QUERY_VARIANTS: { host: string; ecs?: string }[] = [
-  { host: "dns.alidns.com" },
-  { host: "223.5.5.5" },
-  { host: "223.6.6.6" },
-  { host: "223.5.5.5", ecs: "1.2.3.0/24" },
-  { host: "223.6.6.6", ecs: "202.96.209.0/24" },
+const ALI_DNS_HOSTS = ["dns.alidns.com", "223.5.5.5", "223.6.6.6"];
+const ALI_DNS_ECS_WAVES: (string | undefined)[] = [
+  undefined,
+  "1.2.3.0/24",
+  "8.8.8.0/24",
+  "114.114.114.0/24",
+  "202.96.209.0/24",
+  "77.88.8.0/24",
 ];
+/** Stop early once this many consecutive successful waves add no new records */
+const ALI_DNS_CONVERGED_WAVES = 2;
 
 const queryAliDnsVariant = async (
-  variant: { host: string; ecs?: string },
+  host: string,
+  ecs: string | undefined,
   domain: string
 ): Promise<IDNSQueryResponse> => {
-  const url = new URL(`https://${variant.host}/resolve`);
+  const url = new URL(`https://${host}/resolve`);
   url.searchParams.set("name", domain);
   url.searchParams.set("type", ALI_DNS_TXT_QUERY_TYPE);
-  if (variant.ecs) {
-    url.searchParams.set("edns_client_subnet", variant.ecs);
+  if (ecs) {
+    url.searchParams.set("edns_client_subnet", ecs);
   }
 
   const controller = new AbortController();
@@ -55,34 +66,53 @@ export const aliDnsResolver: CustomDnsResolver = async (domain) => {
     throw new Error("Domain is required");
   }
 
+  const seen = new Set<string>();
+  const mergedAnswers: IDNSRecord[] = [];
+  const responses: IDNSQueryResponse[] = [];
   const errors: unknown[] = [];
-  const results = await Promise.all(
-    ALI_DNS_QUERY_VARIANTS.map(async (variant) => {
-      try {
-        return await queryAliDnsVariant(variant, domain);
-      } catch (error) {
-        errors.push(error);
-        return undefined;
-      }
-    })
-  );
-  const responses = results.filter((result): result is IDNSQueryResponse => result !== undefined);
+  let stagnantWaves = 0;
+
+  let waveIndex = 0;
+  while (waveIndex < ALI_DNS_ECS_WAVES.length && stagnantWaves < ALI_DNS_CONVERGED_WAVES) {
+    const ecs = ALI_DNS_ECS_WAVES[waveIndex];
+    waveIndex += 1;
+    // eslint-disable-next-line no-await-in-loop
+    const waveResults = await Promise.all(
+      ALI_DNS_HOSTS.map(async (host) => {
+        try {
+          return await queryAliDnsVariant(host, ecs, domain);
+        } catch (err) {
+          logError(`query failed for host=${host} ecs=${ecs}: ${err}`);
+          errors.push(err);
+          return undefined;
+        }
+      })
+    );
+    const waveResponses = waveResults.filter((result): result is IDNSQueryResponse => result !== undefined);
+    // A fully failed wave says nothing about coverage, so it must not count towards convergence
+    if (waveResponses.length > 0) {
+      responses.push(...waveResponses);
+
+      let grew = false;
+      waveResponses.forEach((response) => {
+        (response.Answer || []).forEach((record) => {
+          const key = `${record.name}|${record.type}|${record.data}`;
+          if (!seen.has(key)) {
+            seen.add(key);
+            mergedAnswers.push(record);
+            grew = true;
+          }
+        });
+      });
+
+      stagnantWaves = grew ? 0 : stagnantWaves + 1;
+      trace(`wave ecs=${ecs}: merged=${mergedAnswers.length} stagnantWaves=${stagnantWaves}`);
+    }
+  }
 
   if (responses.length === 0) {
     throw errors[0] instanceof Error ? errors[0] : new Error(String(errors[0]));
   }
-
-  const seen = new Set<string>();
-  const mergedAnswers: IDNSRecord[] = [];
-  responses.forEach((response) => {
-    (response.Answer || []).forEach((record) => {
-      const key = `${record.name}|${record.type}|${record.data}`;
-      if (!seen.has(key)) {
-        seen.add(key);
-        mergedAnswers.push(record);
-      }
-    });
-  });
 
   return {
     ...responses[0],

--- a/src/util/dns-resolvers/dns-resolvers.test.ts
+++ b/src/util/dns-resolvers/dns-resolvers.test.ts
@@ -94,29 +94,53 @@ describe("aliDnsResolver", () => {
   });
 
   const answer = (data: string) => ({ name: "ali.example.test.", type: 16, TTL: 300, data });
+  const ALI_HOSTS = ["dns.alidns.com", "223.5.5.5", "223.6.6.6"];
 
-  test("queries all Ali DNS endpoints with name and type 16 (TXT) and merges deduplicated answers", async () => {
-    const requested: string[] = [];
-    const handler = (host: string, records: ReturnType<typeof answer>[]) =>
-      http.get(`https://${host}/resolve`, ({ request }) => {
-        const url = new URL(request.url);
-        expect(url.searchParams.get("name")).toBe("ali.example.test");
-        expect(url.searchParams.get("type")).toBe("16");
-        requested.push(`${url.host}${url.searchParams.has("edns_client_subnet") ? "+ecs" : ""}`);
-        return HttpResponse.json({ ...emptyDnsJson, Answer: records });
-      });
+  test("queries all Ali DNS hosts with name and type 16 (TXT), uses ECS cache-busting, and merges deduplicated answers", async () => {
+    const requestedHosts = new Set<string>();
+    let ecsRequests = 0;
+    const recordsByHost: { [host: string]: ReturnType<typeof answer>[] } = {
+      "dns.alidns.com": [answer("record-a")],
+      "223.5.5.5": [answer("record-a"), answer("record-b")],
+      "223.6.6.6": [answer("record-c")],
+    };
 
     server = setupServer(
-      handler("dns.alidns.com", [answer("record-a")]),
-      handler("223.5.5.5", [answer("record-a"), answer("record-b")]),
-      handler("223.6.6.6", [answer("record-c")])
+      ...ALI_HOSTS.map((host) =>
+        http.get(`https://${host}/resolve`, ({ request }) => {
+          const url = new URL(request.url);
+          expect(url.searchParams.get("name")).toBe("ali.example.test");
+          expect(url.searchParams.get("type")).toBe("16");
+          requestedHosts.add(url.host);
+          if (url.searchParams.has("edns_client_subnet")) ecsRequests += 1;
+          return HttpResponse.json({ ...emptyDnsJson, Answer: recordsByHost[host] });
+        })
+      )
     );
     server.listen();
 
     const out = await aliDnsResolver("ali.example.test");
     const merged = out.Answer.map((r) => r.data).sort();
     expect(merged).toEqual(["record-a", "record-b", "record-c"]);
-    expect(requested.sort()).toEqual(["223.5.5.5", "223.5.5.5+ecs", "223.6.6.6", "223.6.6.6+ecs", "dns.alidns.com"]);
+    expect(Array.from(requestedHosts).sort()).toEqual(ALI_HOSTS.slice().sort());
+    expect(ecsRequests).toBeGreaterThan(0);
+  });
+
+  test("stops querying once the merged answer set converges", async () => {
+    let requestCount = 0;
+    server = setupServer(
+      ...ALI_HOSTS.map((host) =>
+        http.get(`https://${host}/resolve`, () => {
+          requestCount += 1;
+          return HttpResponse.json({ ...emptyDnsJson, Answer: [answer("record-a")] });
+        })
+      )
+    );
+    server.listen();
+
+    await aliDnsResolver("ali.example.test");
+    // 6 ECS waves x 3 hosts = 18 possible requests; convergence must stop it well short of that
+    expect(requestCount).toBeLessThan(18);
   });
 
   test("returns merged answers from remaining endpoints when some endpoints fail", async () => {
@@ -131,11 +155,27 @@ describe("aliDnsResolver", () => {
     expect(out.Answer.map((r) => r.data)).toEqual(["record-a"]);
   });
 
+  test("does not count fully failed waves towards convergence", async () => {
+    // The first wave carries no edns_client_subnet parameter and fails entirely;
+    // later ECS waves succeed, so the resolver must still return their records.
+    server = setupServer(
+      ...ALI_HOSTS.map((host) =>
+        http.get(`https://${host}/resolve`, ({ request }) => {
+          const url = new URL(request.url);
+          if (!url.searchParams.has("edns_client_subnet")) return new HttpResponse(null, { status: 503 });
+          return HttpResponse.json({ ...emptyDnsJson, Answer: [answer("record-a")] });
+        })
+      )
+    );
+    server.listen();
+
+    const out = await aliDnsResolver("ali.example.test");
+    expect(out.Answer.map((r) => r.data)).toEqual(["record-a"]);
+  });
+
   test("throws when all Ali DNS endpoints return non-2xx", async () => {
     server = setupServer(
-      http.get("https://dns.alidns.com/resolve", () => new HttpResponse(null, { status: 503 })),
-      http.get("https://223.5.5.5/resolve", () => new HttpResponse(null, { status: 503 })),
-      http.get("https://223.6.6.6/resolve", () => new HttpResponse(null, { status: 503 }))
+      ...ALI_HOSTS.map((host) => http.get(`https://${host}/resolve`, () => new HttpResponse(null, { status: 503 })))
     );
     server.listen();
 

--- a/src/util/dns-resolvers/dns-resolvers.test.ts
+++ b/src/util/dns-resolvers/dns-resolvers.test.ts
@@ -155,6 +155,27 @@ describe("aliDnsResolver", () => {
     expect(out.Answer.map((r) => r.data)).toEqual(["record-a"]);
   });
 
+  test("does not count consecutive fully failed waves towards convergence", async () => {
+    // Fail each host's first two requests — i.e. the first two whole waves — regardless
+    // of which ECS values the strategy uses. Without the failed-wave guard, two failed
+    // waves reach the convergence threshold and the resolver aborts before ever seeing
+    // an answer; with the guard it keeps going and succeeds on the third wave.
+    const failuresPerHost: { [host: string]: number } = {};
+    server = setupServer(
+      ...ALI_HOSTS.map((host) =>
+        http.get(`https://${host}/resolve`, () => {
+          failuresPerHost[host] = (failuresPerHost[host] || 0) + 1;
+          if (failuresPerHost[host] <= 2) return new HttpResponse(null, { status: 503 });
+          return HttpResponse.json({ ...emptyDnsJson, Answer: [answer("record-a")] });
+        })
+      )
+    );
+    server.listen();
+
+    const out = await aliDnsResolver("ali.example.test");
+    expect(out.Answer.map((r) => r.data)).toEqual(["record-a"]);
+  });
+
   test("does not count fully failed waves towards convergence", async () => {
     // The first wave carries no edns_client_subnet parameter and fails entirely;
     // later ECS waves succeed, so the resolver must still return their records.

--- a/src/util/dns-resolvers/dns-resolvers.test.ts
+++ b/src/util/dns-resolvers/dns-resolvers.test.ts
@@ -93,23 +93,50 @@ describe("aliDnsResolver", () => {
     server?.close();
   });
 
-  test("requests Ali DNS JSON with name, type 16 (TXT), and encoded query", async () => {
-    server = setupServer(
-      http.get("https://dns.alidns.com/resolve", ({ request }) => {
+  const answer = (data: string) => ({ name: "ali.example.test.", type: 16, TTL: 300, data });
+
+  test("queries all Ali DNS endpoints with name and type 16 (TXT) and merges deduplicated answers", async () => {
+    const requested: string[] = [];
+    const handler = (host: string, records: ReturnType<typeof answer>[]) =>
+      http.get(`https://${host}/resolve`, ({ request }) => {
         const url = new URL(request.url);
-        expect(url.searchParams.get("name")).toBe("ali example.test");
+        expect(url.searchParams.get("name")).toBe("ali.example.test");
         expect(url.searchParams.get("type")).toBe("16");
-        return HttpResponse.json(emptyDnsJson);
-      })
+        requested.push(`${url.host}${url.searchParams.has("edns_client_subnet") ? "+ecs" : ""}`);
+        return HttpResponse.json({ ...emptyDnsJson, Answer: records });
+      });
+
+    server = setupServer(
+      handler("dns.alidns.com", [answer("record-a")]),
+      handler("223.5.5.5", [answer("record-a"), answer("record-b")]),
+      handler("223.6.6.6", [answer("record-c")])
     );
     server.listen();
 
-    const out = await aliDnsResolver("ali example.test");
-    expect(out).toMatchObject({ Status: 0, Answer: [] });
+    const out = await aliDnsResolver("ali.example.test");
+    const merged = out.Answer.map((r) => r.data).sort();
+    expect(merged).toEqual(["record-a", "record-b", "record-c"]);
+    expect(requested.sort()).toEqual(["223.5.5.5", "223.5.5.5+ecs", "223.6.6.6", "223.6.6.6+ecs", "dns.alidns.com"]);
   });
 
-  test("throws when Ali DNS returns non-2xx", async () => {
-    server = setupServer(http.get("https://dns.alidns.com/resolve", () => new HttpResponse(null, { status: 503 })));
+  test("returns merged answers from remaining endpoints when some endpoints fail", async () => {
+    server = setupServer(
+      http.get("https://dns.alidns.com/resolve", () => new HttpResponse(null, { status: 503 })),
+      http.get("https://223.5.5.5/resolve", () => new HttpResponse(null, { status: 503 })),
+      http.get("https://223.6.6.6/resolve", () => HttpResponse.json({ ...emptyDnsJson, Answer: [answer("record-a")] }))
+    );
+    server.listen();
+
+    const out = await aliDnsResolver("ali.example.test");
+    expect(out.Answer.map((r) => r.data)).toEqual(["record-a"]);
+  });
+
+  test("throws when all Ali DNS endpoints return non-2xx", async () => {
+    server = setupServer(
+      http.get("https://dns.alidns.com/resolve", () => new HttpResponse(null, { status: 503 })),
+      http.get("https://223.5.5.5/resolve", () => new HttpResponse(null, { status: 503 })),
+      http.get("https://223.6.6.6/resolve", () => new HttpResponse(null, { status: 503 }))
+    );
     server.listen();
 
     await expect(aliDnsResolver("ali.example.test")).rejects.toThrow(/HTTP 503/);


### PR DESCRIPTION
## Summary

AliDNS (`dns.alidns.com`) silently omits TXT records on domains with larger TXT record sets — including `openatts` records, which are exactly what this library exists to read — while reporting `TC: false`, so consumers get an incomplete answer with no signal that anything is missing. Because the resolver chain stops at the first successful response, a truncated AliDNS answer can cause dnsprove to miss valid, existing records.

The truncation is a hard per-response cap, not a transient glitch (credit to @rongquan1 for pinning this down): every AliDNS response is cut at roughly 12–14 TXT records regardless of the advertised EDNS buffer size, on all hosts and transports. A single query genuinely cannot read a larger record set — merging multiple partial views is the only way to recover it.

This PR keeps AliDNS (it is the only China-accessible DoH JSON endpoint that sends CORS headers, so it is the only one usable from browsers behind the Great Firewall) but makes the resolver merge across cache windows: AliDNS serves the same DoH service on three hosts (`dns.alidns.com`, `223.5.5.5`, `223.6.6.6` — all with `Access-Control-Allow-Origin: *` and valid TLS), each with its own cache, and the cache is additionally keyed on the `edns_client_subnet` (ECS) parameter. Each host/ECS combination therefore exposes a different partial window onto the record set.

`aliDnsResolver` now queries in waves of three (one request per host, all sharing that wave's ECS value, 10s timeout per request), merges the deduplicated answers, and stops once two consecutive successful waves add no new records — up to 6 waves / 18 requests, typically 12–15. Fully failed waves don't count towards convergence, and per-query failures are logged via the `debug` logger rather than swallowed; the resolver only throws if every query fails.

No API changes: `aliDnsResolver` keeps its name, signature, and position (last) in `defaultDnsResolvers`.

## Evidence of AliDNS truncation

Queried via each resolver's JSON API (`type=16`, 2026-08-23):

| Endpoint | `accredify.io` (21 TXT) | `tradetrust.io` (22 TXT) | TC flag |
| --- | --- | --- | --- |
| `dns.google` | 21 | 22 | false |
| `cloudflare-dns.com` | 21 | 22 | false |
| single AliDNS query | **12–14** | **12–14** | false |

Every single AliDNS query drops records — on `accredify.io` typically 7 of 21, including 4 `openatts` records (both `net=ethereum` document-store records and `a=dns-did` records). Reproduce with:

```sh
curl -s "https://dns.alidns.com/resolve?name=accredify.io&type=16" | jq '[.Answer[] | select(.type==16)] | length'   # 12-14
curl -s "https://dns.google/resolve?name=accredify.io&type=16"    | jq '[.Answer[] | select(.type==16)] | length'   # 21
```

## Why not switch providers instead

Alternative China-accessible DoH endpoints were evaluated and ruled out:

| Endpoint | Complete answers | CORS |
| --- | --- | --- |
| `doh.360.cn` | ✅ complete | ❌ no `Access-Control-Allow-Origin` — browser fetch blocked |
| `doh.pub` (Tencent) | ❌ 4/21, `TC: false` | ❌ none |
| `dns.alidns.com` / `223.5.5.5` / `223.6.6.6` | partial per query, complete when merged | ✅ `*` |

dnsprove runs in browsers (TradeTrust verifier), so a resolver without CORS headers is dead code there. AliDNS is the only option that works in browsers from China — it just needs the cache-window merge to be reliable.

## Validation

Measured against Google as ground truth, going through dnsprove's real resolver code:

- Single AliDNS query: 12–14 records on both test domains, `openatts` records missing every time.
- A fixed set of 5 host/ECS variants (this PR's earlier revision): complete on `accredify.io` (21 records), but short in 2 of 15 rounds on `tradetrust.io` (22 records, 18–20 recovered) — cache windows can overlap too heavily for any fixed variant list.
- Adaptive waves (current revision): **complete record set in 30/30 rounds** — 20/20 on `tradetrust.io`, 10/10 on `accredify.io` — at 12–15 requests per resolution.

To be clear about the residual risk: coverage is probabilistic — the resolver widens its ECS sampling until the merged set stops growing, which measured 30/30 here but is not a structural guarantee for arbitrarily large record sets. It strictly dominates both the status quo (a single truncated query) and any fixed variant list, and it degrades gracefully: whatever subset is recovered is still a merged superset of any individual query.

## Changes

- `aliDnsResolver` queries `dns.alidns.com`, `223.5.5.5`, `223.6.6.6` in waves sharing a per-wave `edns_client_subnet` value (6-value ECS pool), merges `Answer` records deduplicated by `name|type|data` (TTL deliberately excluded — the caches return differing TTLs for the same record), and stops after 2 consecutive successful waves without growth
- Fully failed waves are excluded from convergence counting; individual query failures are logged via `debug` (`dnsprove:error:ali-dns-resolver`); the resolver throws only if all queries fail
- `AD` is the conjunction across merged responses
- Tests cover merge/dedup, ECS usage, convergence early-stop, failed-wave guard, partial and total endpoint failure — without pinning the exact query strategy

## Testing

- `npm run type-check` and `npm run lint` pass
- `npx jest` — 38/38 tests pass
